### PR TITLE
Added missing comma from appwrite.json

### DIFF
--- a/appwrite.json
+++ b/appwrite.json
@@ -45,7 +45,7 @@
             ],
             "indexes": []
         }
-    ]
+    ],
     "functions": [
         {
             "$id": "createPaymentIntent",


### PR DESCRIPTION
Comma is missing, causing `appwrite deploy collection` to fail.